### PR TITLE
Modify image fill in Sidebar.tsx

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -86,7 +86,7 @@ export default function Sidebar(props: {}) {
             <Box className={cn('flex title-bar items-center', needRoomForMacWindowControls ? 'pt-12' : 'pt-3')}></Box>
             <Box className={cn('flex justify-between items-center p-0 m-0 mx-2 mb-2')}>
               <Box className="title-bar">
-                <img src={icon} className="w-6 h-6 mr-2 align-middle inline-block" />
+                <img src={icon} className="w-6 h-6 mr-2 align-middle inline-block object-cover" />
                 {/* <span className="text-xl font-semibold align-middle inline-block opacity-75">Chatbox</span> */}
                 <span className="text-xl font-semibold align-middle inline-block opacity-75">{ENV.APP_NAME}</span>
               </Box>


### PR DESCRIPTION
Modify the application icon's filling method in the sidebar to `object-cover` to ensure it maintains its aspect ratio and covers the container.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c709fc5-2e73-4150-9385-68d0b7066a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c709fc5-2e73-4150-9385-68d0b7066a69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>